### PR TITLE
refactor: replace specialized types, which used in APIs, with primitive rust types

### DIFF
--- a/prover/src/tests/service.rs
+++ b/prover/src/tests/service.rs
@@ -143,16 +143,17 @@ fn test_spv_client(
 
                 log::debug!(">>> with confirmations {confirmations}");
 
+                let txid_array = txid.as_ref();
                 let verify_result = tip_client
-                    .verify_transaction(&txid, tx_proof.as_reader(), confirmations - 1)
+                    .verify_transaction(txid_array, tx_proof.as_reader(), confirmations - 1)
                     .map_err(|err| err as i8);
                 assert!(verify_result.is_ok());
                 let verify_result = tip_client
-                    .verify_transaction(&txid, tx_proof.as_reader(), confirmations)
+                    .verify_transaction(txid_array, tx_proof.as_reader(), confirmations)
                     .map_err(|err| err as i8);
                 assert!(verify_result.is_ok());
                 let verify_result = tip_client
-                    .verify_transaction(&txid, tx_proof.as_reader(), confirmations + 1)
+                    .verify_transaction(txid_array, tx_proof.as_reader(), confirmations + 1)
                     .map_err(|err| err as i8);
                 assert!(verify_result.is_err());
             }

--- a/verifier/src/types/extension/packed.rs
+++ b/verifier/src/types/extension/packed.rs
@@ -268,7 +268,7 @@ impl packed::SpvClient {
         let tx: core::Transaction =
             deserialize(tx).map_err(|_| VerifyTxError::DecodeTransaction)?;
         let txid = tx.txid();
-        let header = self.verify_transaction(&txid, tx_proof, confirmations)?;
+        let header = self.verify_transaction(txid.as_ref(), tx_proof, confirmations)?;
         Ok((header, tx))
     }
 
@@ -286,7 +286,7 @@ impl packed::SpvClient {
     /// If you don't need it, just ignore it.
     pub fn verify_transaction(
         &self,
-        txid: &core::Txid,
+        txid: &[u8; 32],
         tx_proof: packed::TransactionProofReader,
         confirmations: u32,
     ) -> Result<core::Header, VerifyTxError> {
@@ -328,8 +328,9 @@ impl packed::SpvClient {
                 .position(|v| v == tx_index)
                 .map(|i| matches[i])
                 .ok_or(VerifyTxError::TxOutProofInvalidTxIndex)
-                .and_then(|ref id| {
-                    if id == txid {
+                .and_then(|id| {
+                    let id_bytes: &[u8; 32] = id.as_ref();
+                    if id_bytes == txid {
                         Ok(())
                     } else {
                         Err(VerifyTxError::TxOutProofInvalidTxId)


### PR DESCRIPTION
To simplify the APIs, so users don't have to import types from the `bitcoin` crate.

```diff
    pub fn verify_transaction(
        &self,
-       txid: &core::Txid,
+       txid: &[u8; 32],
        tx_proof: packed::TransactionProofReader,
        confirmations: u32,
    ) -> Result<core::Header, VerifyTxError> {
```