### PR TITLE
feat: add 8 bit-flags into script type args to control features

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CARGO := @cargo
 
-MOLC := @moleculec
+MOLC := moleculec
 MOLC_VERSION := 0.7.5
 
 NEXTEST_RUN_ARGS := --no-fail-fast --success-output never --failure-output final

--- a/prover/src/tests/service.rs
+++ b/prover/src/tests/service.rs
@@ -85,7 +85,7 @@ fn test_spv_client(
         let new_client: packed::SpvClient = service.tip_client().pack();
 
         old_client
-            .verify_new_client(&new_client, update)
+            .verify_new_client(&new_client, update, 0)
             .map_err(|err| err as i8)
             .unwrap();
         old_client = new_client;

--- a/verifier/schemas/types.mol
+++ b/verifier/schemas/types.mol
@@ -53,6 +53,7 @@ struct SpvClient {
 struct SpvTypeArgs {
     type_id: Hash,
     clients_count: byte,
+    flags: byte,
 }
 
 //

--- a/verifier/src/constants.rs
+++ b/verifier/src/constants.rs
@@ -1,0 +1,3 @@
+//! Constants.
+
+pub const FLAG_DISABLE_DIFFICULTY_CHECK: u8 = 0b1000_0000;

--- a/verifier/src/lib.rs
+++ b/verifier/src/lib.rs
@@ -11,6 +11,7 @@ extern crate core;
 #[macro_use]
 mod log;
 
+pub mod constants;
 pub mod error;
 pub mod types;
 pub mod utilities;

--- a/verifier/src/types/conversion/pack.rs
+++ b/verifier/src/types/conversion/pack.rs
@@ -104,6 +104,7 @@ impl Pack<packed::SpvTypeArgs> for core::SpvTypeArgs {
         packed::SpvTypeArgs::new_builder()
             .type_id(self.type_id.pack())
             .clients_count(self.clients_count.into())
+            .flags(self.flags.into())
             .build()
     }
 }

--- a/verifier/src/types/conversion/unpack.rs
+++ b/verifier/src/types/conversion/unpack.rs
@@ -104,6 +104,7 @@ impl<'r> Unpack<core::SpvTypeArgs> for packed::SpvTypeArgsReader<'r> {
         core::SpvTypeArgs {
             type_id: self.type_id().unpack(),
             clients_count: self.clients_count().into(),
+            flags: self.flags().into(),
         }
     }
 }

--- a/verifier/src/types/core.rs
+++ b/verifier/src/types/core.rs
@@ -84,6 +84,12 @@ pub struct SpvTypeArgs {
     ///
     /// N.B. Exclude the SPV info cell.
     pub clients_count: u8,
+    /// Bit flags to control features.
+    ///
+    /// From high to low:
+    /// - Set 0-th bit to true, to disable difficulty checks.
+    /// - Other bits are reserved.
+    pub flags: u8,
 }
 
 #[cfg(feature = "std")]

--- a/verifier/src/types/generated/types.rs
+++ b/verifier/src/types/generated/types.rs
@@ -3499,6 +3499,7 @@ impl ::core::fmt::Display for SpvTypeArgs {
         write!(f, "{} {{ ", Self::NAME)?;
         write!(f, "{}: {}", "type_id", self.type_id())?;
         write!(f, ", {}: {}", "clients_count", self.clients_count())?;
+        write!(f, ", {}: {}", "flags", self.flags())?;
         write!(f, " }}")
     }
 }
@@ -3509,18 +3510,21 @@ impl ::core::default::Default for SpvTypeArgs {
     }
 }
 impl SpvTypeArgs {
-    const DEFAULT_VALUE: [u8; 33] = [
+    const DEFAULT_VALUE: [u8; 34] = [
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0,
+        0, 0, 0, 0,
     ];
-    pub const TOTAL_SIZE: usize = 33;
-    pub const FIELD_SIZES: [usize; 2] = [32, 1];
-    pub const FIELD_COUNT: usize = 2;
+    pub const TOTAL_SIZE: usize = 34;
+    pub const FIELD_SIZES: [usize; 3] = [32, 1, 1];
+    pub const FIELD_COUNT: usize = 3;
     pub fn type_id(&self) -> Hash {
         Hash::new_unchecked(self.0.slice(0..32))
     }
     pub fn clients_count(&self) -> Byte {
         Byte::new_unchecked(self.0.slice(32..33))
+    }
+    pub fn flags(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(33..34))
     }
     pub fn as_reader<'r>(&'r self) -> SpvTypeArgsReader<'r> {
         SpvTypeArgsReader::new_unchecked(self.as_slice())
@@ -3551,6 +3555,7 @@ impl molecule::prelude::Entity for SpvTypeArgs {
         Self::new_builder()
             .type_id(self.type_id())
             .clients_count(self.clients_count())
+            .flags(self.flags())
     }
 }
 #[derive(Clone, Copy)]
@@ -3574,18 +3579,22 @@ impl<'r> ::core::fmt::Display for SpvTypeArgsReader<'r> {
         write!(f, "{} {{ ", Self::NAME)?;
         write!(f, "{}: {}", "type_id", self.type_id())?;
         write!(f, ", {}: {}", "clients_count", self.clients_count())?;
+        write!(f, ", {}: {}", "flags", self.flags())?;
         write!(f, " }}")
     }
 }
 impl<'r> SpvTypeArgsReader<'r> {
-    pub const TOTAL_SIZE: usize = 33;
-    pub const FIELD_SIZES: [usize; 2] = [32, 1];
-    pub const FIELD_COUNT: usize = 2;
+    pub const TOTAL_SIZE: usize = 34;
+    pub const FIELD_SIZES: [usize; 3] = [32, 1, 1];
+    pub const FIELD_COUNT: usize = 3;
     pub fn type_id(&self) -> HashReader<'r> {
         HashReader::new_unchecked(&self.as_slice()[0..32])
     }
     pub fn clients_count(&self) -> ByteReader<'r> {
         ByteReader::new_unchecked(&self.as_slice()[32..33])
+    }
+    pub fn flags(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[33..34])
     }
 }
 impl<'r> molecule::prelude::Reader<'r> for SpvTypeArgsReader<'r> {
@@ -3613,17 +3622,22 @@ impl<'r> molecule::prelude::Reader<'r> for SpvTypeArgsReader<'r> {
 pub struct SpvTypeArgsBuilder {
     pub(crate) type_id: Hash,
     pub(crate) clients_count: Byte,
+    pub(crate) flags: Byte,
 }
 impl SpvTypeArgsBuilder {
-    pub const TOTAL_SIZE: usize = 33;
-    pub const FIELD_SIZES: [usize; 2] = [32, 1];
-    pub const FIELD_COUNT: usize = 2;
+    pub const TOTAL_SIZE: usize = 34;
+    pub const FIELD_SIZES: [usize; 3] = [32, 1, 1];
+    pub const FIELD_COUNT: usize = 3;
     pub fn type_id(mut self, v: Hash) -> Self {
         self.type_id = v;
         self
     }
     pub fn clients_count(mut self, v: Byte) -> Self {
         self.clients_count = v;
+        self
+    }
+    pub fn flags(mut self, v: Byte) -> Self {
+        self.flags = v;
         self
     }
 }
@@ -3636,6 +3650,7 @@ impl molecule::prelude::Builder for SpvTypeArgsBuilder {
     fn write<W: molecule::io::Write>(&self, writer: &mut W) -> molecule::io::Result<()> {
         writer.write_all(self.type_id.as_slice())?;
         writer.write_all(self.clients_count.as_slice())?;
+        writer.write_all(self.flags.as_slice())?;
         Ok(())
     }
     fn build(&self) -> Self::Entity {


### PR DESCRIPTION
### Issue

- Bitcoin has a formula[^1] to calculate target difficulties.

- But Bitcoin testnet has the following rule[^2]:

  > In addition, if no block has been found in 20 minutes, the difficulty automatically resets back to the minimum for a single block, after which it returns to its previous value.

So, if I want to use a same script to create both mainnet and testnet SPV instance on CKB, flags to control the checks are required.

[^1]: [What is the formula for difficulty?](https://en.bitcoin.it/wiki/Difficulty#What_is_the_formula_for_difficulty.3F)
[^2]: [Differences between Mainnet and Testnet](https://en.bitcoin.it/wiki/Testnet#Differences) 