### PR TITLE
fix: the next target for testnet

### DIFF
--- a/verifier/src/types/extension/packed.rs
+++ b/verifier/src/types/extension/packed.rs
@@ -167,7 +167,10 @@ impl packed::SpvClient {
                 match (new_max_height + 1) % DIFFCHANGE_INTERVAL {
                     // Next block is the first block for a new difficulty.
                     0 => {
-                        let prev_target = new_info.1.into();
+                        // See the above check:
+                        // - For mainnet, `header.bits` should be as the same as `new_info.1`.
+                        // - But for testnet, it could be not.
+                        let prev_target = header.bits.into();
                         let next_target =
                             calculate_next_target(prev_target, new_info.0, header.time);
                         new_info.1 = next_target.to_compact_lossy();


### PR DESCRIPTION
### Description

For Bitcoin main chain, the targets in every 2016 blocks are the same.

But for Bitcoin testnet, the target could be changed during every 2016 blocks.
https://github.com/ckb-cell/ckb-bitcoin-spv/blob/27953a4c6b1e898396c47091a6b5bc03c782a238/verifier/src/types/extension/packed.rs#L142-L155

When calculate the next target, the prev target should be the last block target, not the last expected target.