### PR TITLE
fix: overflow in `calculate_next_target` to match Bitcoin Core

### DIFF
--- a/verifier/src/utilities/bitcoin.rs
+++ b/verifier/src/utilities/bitcoin.rs
@@ -20,16 +20,16 @@ pub fn calculate_next_target(
     end_time: u32,
     flags: u8,
 ) -> Target {
-    let expected = DIFFCHANGE_TIMESPAN;
+    let expected = DIFFCHANGE_TIMESPAN as i64;
     let actual = {
-        let mut actual = end_time - start_time;
+        let mut actual = (end_time as i64) - (start_time as i64);
         if actual < expected / 4 {
             actual = expected / 4;
         }
         if actual > expected * 4 {
             actual = expected * 4;
         }
-        actual
+        actual as u32
     };
 
     let le_bytes = {


### PR DESCRIPTION
Converted `start_time` and `end_time` to `i64` for safe subtraction, avoiding overflow in nActualTimespan. Ensures consistency with Bitcoin Core’s difficulty adjustment logic [`CalculateNextWorkRequired(..)` in Bitcoin source code](https://github.com/bitcoin/bitcoin/blob/v26.0/src/pow.cpp#L49).

service side log:
```bash
[2024-11-04T08:30:10Z INFO  ckb_bitcoin_spv_service::cli::serve] Try to update SPV instance
thread 'main' panicked at /usr/local/cargo/git/checkouts/ckb-bitcoin-spv-984d49c27aa7958d/bfc71d7/verifier/src/utilities/bitcoin.rs:25:26:
attempt to subtract with overflow
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```